### PR TITLE
Domain entities and value objects added

### DIFF
--- a/src/PetFamily.Domain/Pet/Pet.cs
+++ b/src/PetFamily.Domain/Pet/Pet.cs
@@ -1,0 +1,70 @@
+using CSharpFunctionalExtensions;
+using PetFamily.Domain.Pet.ValueObjects;
+using PetFamily.Domain.Shared.ValueObjects;
+using PetFamily.Domain.Species.ValueObjects;
+
+namespace PetFamily.Domain.Pet;
+
+public class Pet : Entity
+{
+    public new PetId Id { get; init; }
+    public SpecieId SpecieId { get; init; }
+    public BreedId BreedId { get; init; }
+    public PetCreationDate CreationDate { get; init; }
+    public PetBirthday Birthday { get; init; }
+    public PetName Name { get; private set; }
+    public PetBodyMetrics BodyMetrics { get; private set; }
+    public PetHealthStatus PetHealth { get; private set; } = new NeitherVaccinatedNorCastrated();
+    public Description Description { get; private set; } = Description.Empty;
+    public PetHelpStatus HelpStatus { get; private set; }
+    public PetAddress Address { get; private set; }
+    public Contacts OwnerContacts { get; private set; }
+    public PetColor Color { get; private set; }
+
+    public Pet(
+        PetName name,
+        SpecieId specieId,
+        BreedId breedId,
+        PetBodyMetrics bodyMetrics,
+        PetColor color,
+        PetBirthday birthday,
+        PetAddress address,
+        Contacts ownerContacts,
+        PetHelpStatus helpStatus,
+        PetHealthStatus? healthStatus = null,
+        Description? description = null
+    )
+    {
+        Name = name;
+        Id = new PetId();
+        SpecieId = specieId;
+        BreedId = breedId;
+        BodyMetrics = bodyMetrics;
+        Birthday = birthday;
+        Address = address;
+        OwnerContacts = ownerContacts;
+        HelpStatus = helpStatus;
+        Color = color;
+        CreationDate = new PetCreationDate();
+        if (healthStatus != null)
+            PetHealth = healthStatus;
+        if (description != null)
+            Description = description;
+    }
+
+    public void UpdatePetName(PetName newName) => Name = newName;
+
+    public void UpdatePetBodyMetrics(PetBodyMetrics newBodyMetrics) => BodyMetrics = newBodyMetrics;
+
+    public void UpdatePetHealthStatus(PetHealthStatus newStatus) => PetHealth = newStatus;
+
+    public void UpdatePetDescription(Description newDescription) => Description = newDescription;
+
+    public void UpdatePetHelpStatus(PetHelpStatus newStatus) => HelpStatus = newStatus;
+
+    public void UpdatePetAddress(PetAddress newAddress) => Address = newAddress;
+
+    public void UpdatePetOwnerContacts(Contacts newContacts) => OwnerContacts = newContacts;
+
+    public void UpdatePetColor(PetColor newColor) => Color = newColor;
+}

--- a/src/PetFamily.Domain/Pet/ValueObjects/PetAddress.cs
+++ b/src/PetFamily.Domain/Pet/ValueObjects/PetAddress.cs
@@ -1,0 +1,27 @@
+using CSharpFunctionalExtensions;
+
+namespace PetFamily.Domain.Pet.ValueObjects;
+
+public record PetAddress
+{
+    public string Address { get; }
+
+    private PetAddress(string address) => Address = address;
+
+    public static Result<PetAddress> Create(string? address) =>
+        address switch
+        {
+            null => Result.Failure<PetAddress>(PetAddressErrors.AddressIsNull()),
+            not null when string.IsNullOrWhiteSpace(address) => Result.Failure<PetAddress>(
+                PetAddressErrors.AddressWasEmpty()
+            ),
+            _ => new PetAddress(address),
+        };
+}
+
+public static class PetAddressErrors
+{
+    public static string AddressIsNull() => "Address was null";
+
+    public static string AddressWasEmpty() => "Address was empty";
+}

--- a/src/PetFamily.Domain/Pet/ValueObjects/PetBirthday.cs
+++ b/src/PetFamily.Domain/Pet/ValueObjects/PetBirthday.cs
@@ -1,0 +1,23 @@
+using CSharpFunctionalExtensions;
+
+namespace PetFamily.Domain.Pet.ValueObjects;
+
+public record PetBirthday
+{
+    public DateOnly Value { get; }
+
+    private PetBirthday(DateOnly date) => Value = date;
+
+    public static Result<PetBirthday> Create(DateOnly birthDay)
+    {
+        DateOnly today = DateOnly.FromDateTime(DateTime.Today);
+        if (birthDay > today)
+            return Result.Failure<PetBirthday>(PetBirthdayErrors.DateIsMoreThanCurrentDate());
+        return new PetBirthday(birthDay);
+    }
+}
+
+public static class PetBirthdayErrors
+{
+    public static string DateIsMoreThanCurrentDate() => "Pet cannot be in the future";
+}

--- a/src/PetFamily.Domain/Pet/ValueObjects/PetBodyMetrics.cs
+++ b/src/PetFamily.Domain/Pet/ValueObjects/PetBodyMetrics.cs
@@ -1,0 +1,47 @@
+using CSharpFunctionalExtensions;
+
+namespace PetFamily.Domain.Pet.ValueObjects;
+
+public record PetBodyMetrics
+{
+    private const double MaxWeight = 500;
+    private const double MaxHeight = 500;
+
+    public double Weight { get; }
+    public double Height { get; }
+
+    private PetBodyMetrics(double weight, double height)
+    {
+        Weight = weight;
+        Height = height;
+    }
+
+    public static Result<PetBodyMetrics> Create(double weight, double heigth) =>
+        (weight, heigth) switch
+        {
+            (<= 0, _) => Result.Failure<PetBodyMetrics>(
+                PetBodyMetricsErrors.WeightIsLessThanZero()
+            ),
+            (_, <= 0) => Result.Failure<PetBodyMetrics>(
+                PetBodyMetricsErrors.HeightIsLessThanZero()
+            ),
+            (> MaxWeight, _) => Result.Failure<PetBodyMetrics>(
+                PetBodyMetricsErrors.WeirdWeightError()
+            ),
+            (_, > MaxHeight) => Result.Failure<PetBodyMetrics>(
+                PetBodyMetricsErrors.WeirdHeightError()
+            ),
+            _ => new PetBodyMetrics(weight, heigth),
+        };
+}
+
+public static class PetBodyMetricsErrors
+{
+    public static string WeightIsLessThanZero() => "Pet weight should be greater than 0";
+
+    public static string HeightIsLessThanZero() => "Pet height should be greater than 0";
+
+    public static string WeirdWeightError() => "Pet weight is weird";
+
+    public static string WeirdHeightError() => "Pet height is weird";
+}

--- a/src/PetFamily.Domain/Pet/ValueObjects/PetColor.cs
+++ b/src/PetFamily.Domain/Pet/ValueObjects/PetColor.cs
@@ -1,0 +1,36 @@
+using CSharpFunctionalExtensions;
+using PetFamily.Domain.Species.ValueObjects;
+
+namespace PetFamily.Domain.Pet.ValueObjects;
+
+public record PetColor
+{
+    private const int MaxColorValueLength = 20;
+
+    public string ColorValue { get; }
+
+    private PetColor(string colorValue) => ColorValue = colorValue;
+
+    public static Result<PetColor> Create(string? colorValue) =>
+        colorValue switch
+        {
+            null => Result.Failure<PetColor>(PetColorErrors.PetColorWasNull()),
+            not null when string.IsNullOrWhiteSpace(colorValue) => Result.Failure<PetColor>(
+                SpecieTypeErrors.SpecieTypeEmptyError()
+            ),
+            not null when colorValue.Length > MaxColorValueLength => Result.Failure<PetColor>(
+                SpecieTypeErrors.SpecieTypeExceedsLength(MaxColorValueLength)
+            ),
+            _ => new PetColor(colorValue),
+        };
+}
+
+public static class PetColorErrors
+{
+    public static string PetColorWasNull() => "Pet color color was null";
+
+    public static string PetColorWasEmpty() => "Pet color color was empty";
+
+    public static string PetColorExceedsLength(int length) =>
+        $"Pet color is more than {length} characters";
+}

--- a/src/PetFamily.Domain/Pet/ValueObjects/PetCreationDate.cs
+++ b/src/PetFamily.Domain/Pet/ValueObjects/PetCreationDate.cs
@@ -1,0 +1,6 @@
+namespace PetFamily.Domain.Pet.ValueObjects;
+
+public record PetCreationDate
+{
+    public DateOnly Date { get; } = DateOnly.FromDateTime(DateTime.Now);
+}

--- a/src/PetFamily.Domain/Pet/ValueObjects/PetHealthStatus.cs
+++ b/src/PetFamily.Domain/Pet/ValueObjects/PetHealthStatus.cs
@@ -1,0 +1,46 @@
+namespace PetFamily.Domain.Pet.ValueObjects;
+
+public abstract record PetHealthStatus
+{
+    public bool IsVaccinated { get; }
+    public bool IsCastrated { get; }
+
+    protected PetHealthStatus(bool isVaccinated, bool isCastrated)
+    {
+        IsVaccinated = isVaccinated;
+        IsCastrated = isCastrated;
+    }
+
+    public static PetHealthStatus Create(bool isVaccinated, bool isCastrated) =>
+        (isCastrated, isCastrated) switch
+        {
+            (true, true) => new VaccinatedAndCastrated(),
+            (false, true) => new CastratedOnly(),
+            (true, false) => new VaccinatedOnly(),
+            _ => new NeitherVaccinatedNorCastrated(),
+        };
+}
+
+public sealed record VaccinatedOnly : PetHealthStatus
+{
+    internal VaccinatedOnly()
+        : base(true, false) { }
+}
+
+public sealed record CastratedOnly : PetHealthStatus
+{
+    internal CastratedOnly()
+        : base(false, true) { }
+}
+
+public sealed record VaccinatedAndCastrated : PetHealthStatus
+{
+    internal VaccinatedAndCastrated()
+        : base(true, true) { }
+}
+
+public sealed record NeitherVaccinatedNorCastrated : PetHealthStatus
+{
+    internal NeitherVaccinatedNorCastrated()
+        : base(false, false) { }
+}

--- a/src/PetFamily.Domain/Pet/ValueObjects/PetHelpStatus.cs
+++ b/src/PetFamily.Domain/Pet/ValueObjects/PetHelpStatus.cs
@@ -1,0 +1,56 @@
+using CSharpFunctionalExtensions;
+
+namespace PetFamily.Domain.Pet.ValueObjects;
+
+public enum PetHelpStatuses
+{
+    RequiresHelp = 0,
+    LookingForHouse = 1,
+    ReceivedHelp = 2,
+}
+
+public abstract record PetHelpStatus
+{
+    public string StatusText;
+    public PetHelpStatuses StatusCode;
+
+    protected PetHelpStatus(string statusText, PetHelpStatuses statusCode)
+    {
+        StatusText = statusText;
+        StatusCode = statusCode;
+    }
+
+    public static Result<PetHelpStatus> Create(int status) =>
+        status switch
+        {
+            (int)PetHelpStatuses.RequiresHelp => new RequiresHelp(PetHelpStatuses.RequiresHelp),
+            (int)PetHelpStatuses.ReceivedHelp => new ReceivedHelp(PetHelpStatuses.ReceivedHelp),
+            (int)PetHelpStatuses.LookingForHouse => new LookingForHouse(
+                PetHelpStatuses.LookingForHouse
+            ),
+            _ => Result.Failure<PetHelpStatus>(PetHelpStatusErrors.UnknownPetHelpStatus()),
+        };
+}
+
+public sealed record RequiresHelp : PetHelpStatus
+{
+    internal RequiresHelp(PetHelpStatuses statusCode)
+        : base("Currently pet requires a help", statusCode) { }
+}
+
+public sealed record LookingForHouse : PetHelpStatus
+{
+    internal LookingForHouse(PetHelpStatuses statusCode)
+        : base("Currently pet is looking for a house", statusCode) { }
+}
+
+public sealed record ReceivedHelp : PetHelpStatus
+{
+    internal ReceivedHelp(PetHelpStatuses statusCode)
+        : base("Pet received a help", statusCode) { }
+}
+
+public static class PetHelpStatusErrors
+{
+    public static string UnknownPetHelpStatus() => "Pet help status is unknown";
+}

--- a/src/PetFamily.Domain/Pet/ValueObjects/PetId.cs
+++ b/src/PetFamily.Domain/Pet/ValueObjects/PetId.cs
@@ -1,0 +1,6 @@
+namespace PetFamily.Domain.Pet.ValueObjects;
+
+public record PetId
+{
+    public Guid Id { get; } = Guid.NewGuid();
+}

--- a/src/PetFamily.Domain/Pet/ValueObjects/PetName.cs
+++ b/src/PetFamily.Domain/Pet/ValueObjects/PetName.cs
@@ -1,0 +1,42 @@
+using System.Text;
+using CSharpFunctionalExtensions;
+
+namespace PetFamily.Domain.Pet.ValueObjects;
+
+public record PetName
+{
+    private const int MaxNameLength = 50;
+
+    public string Value { get; }
+
+    private PetName(string value)
+    {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.Append(char.ToUpper(value[0]));
+        stringBuilder.Append(value.Substring(1));
+        Value = stringBuilder.ToString().Trim();
+    }
+
+    public static Result<PetName> Create(string? name) =>
+        name switch
+        {
+            null => Result.Failure<PetName>(PetNameErrors.NameNullError()),
+            not null when string.IsNullOrWhiteSpace(name) => Result.Failure<PetName>(
+                PetNameErrors.NameEmptyError()
+            ),
+            not null when name.Length > MaxNameLength => Result.Failure<PetName>(
+                PetNameErrors.PetNameExceedsMaximumLengthError(MaxNameLength)
+            ),
+            _ => new PetName(name),
+        };
+}
+
+public static class PetNameErrors
+{
+    public static string NameNullError() => "Pet name was null";
+
+    public static string NameEmptyError() => "Pet name was empty";
+
+    public static string PetNameExceedsMaximumLengthError(int maxLength) =>
+        $"Pet name can't be more {maxLength} characters";
+}

--- a/src/PetFamily.Domain/PetFamily.Domain.csproj
+++ b/src/PetFamily.Domain/PetFamily.Domain.csproj
@@ -6,4 +6,8 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
+    <ItemGroup>
+      <PackageReference Include="CSharpFunctionalExtensions" Version="3.4.3" />
+    </ItemGroup>
+
 </Project>

--- a/src/PetFamily.Domain/Shared/ValueObjects/AccountDetails.cs
+++ b/src/PetFamily.Domain/Shared/ValueObjects/AccountDetails.cs
@@ -1,0 +1,50 @@
+using CSharpFunctionalExtensions;
+
+namespace PetFamily.Domain.Shared.ValueObjects;
+
+public record AccountDetails
+{
+    private const int MaxAccountDetailsDescriptionLength = 500;
+    private const int MaxAccountDetailsNameLength = 100;
+
+    public static AccountDetails Unknown => new AccountDetails("", "");
+
+    public string Description { get; }
+    public string Name { get; }
+
+    private AccountDetails(string description, string name)
+    {
+        Description = description;
+        Name = name;
+    }
+
+    public static Result<AccountDetails> Create(string? description, string? name)
+    {
+        if (string.IsNullOrWhiteSpace(description))
+            return Result.Failure<AccountDetails>(AccountDetailsErrors.DescriptionIsEmpty());
+        if (description.Length > MaxAccountDetailsDescriptionLength)
+            return Result.Failure<AccountDetails>(
+                AccountDetailsErrors.DescriptionExceedsMaxLength(MaxAccountDetailsDescriptionLength)
+            );
+        if (string.IsNullOrWhiteSpace(name))
+            return Result.Failure<AccountDetails>(AccountDetailsErrors.NameIsEmpty());
+        if (name.Length > MaxAccountDetailsNameLength)
+            return Result.Failure<AccountDetails>(
+                AccountDetailsErrors.NameExceedsLength(MaxAccountDetailsNameLength)
+            );
+        return new AccountDetails(description, name);
+    }
+}
+
+public static class AccountDetailsErrors
+{
+    public static string DescriptionIsEmpty() => "Account description was empty";
+
+    public static string DescriptionExceedsMaxLength(int length) =>
+        $"Account description is more than {length} characters";
+
+    public static string NameIsEmpty() => "Account name is empty";
+
+    public static string NameExceedsLength(int length) =>
+        $"Account name is more than {length} characters";
+}

--- a/src/PetFamily.Domain/Shared/ValueObjects/Contacts.cs
+++ b/src/PetFamily.Domain/Shared/ValueObjects/Contacts.cs
@@ -1,0 +1,50 @@
+using CSharpFunctionalExtensions;
+using PetFamily.Domain.Utils;
+
+namespace PetFamily.Domain.Shared.ValueObjects;
+
+public abstract record Contacts
+{
+    public string Phone { get; }
+    public string Email { get; }
+
+    protected Contacts(string phone, string email = "")
+    {
+        Phone = phone;
+        Email = email;
+    }
+
+    public static Result<Contacts> Create(string? phone, string? email)
+    {
+        if (string.IsNullOrWhiteSpace(phone))
+            return Result.Failure<Contacts>(PetOwnerContactsErrors.PhoneWasNull());
+        if (!PhoneValidationHelper.IsPhoneValid(phone))
+            return Result.Failure<Contacts>(PetOwnerContactsErrors.PhoneWasIncorrect());
+        if (!string.IsNullOrWhiteSpace(email) && !EmailValidationHelper.IsEmailValid(email))
+            return Result.Failure<Contacts>(PetOwnerContactsErrors.EmailWasIncorrect());
+        return string.IsNullOrWhiteSpace(email)
+            ? new PhoneOnlyContacts(phone)
+            : new FullContacts(phone, email);
+    }
+}
+
+public sealed record PhoneOnlyContacts : Contacts
+{
+    public PhoneOnlyContacts(string phone)
+        : base(phone) { }
+}
+
+public sealed record FullContacts : Contacts
+{
+    public FullContacts(string phone, string email)
+        : base(phone, email) { }
+}
+
+public static class PetOwnerContactsErrors
+{
+    public static string PhoneWasNull() => "Phone was null";
+
+    public static string PhoneWasIncorrect() => "Phone is incorrect";
+
+    public static string EmailWasIncorrect() => "Email is incorrect";
+}

--- a/src/PetFamily.Domain/Shared/ValueObjects/Description.cs
+++ b/src/PetFamily.Domain/Shared/ValueObjects/Description.cs
@@ -1,0 +1,33 @@
+using CSharpFunctionalExtensions;
+
+namespace PetFamily.Domain.Shared.ValueObjects;
+
+public record Description
+{
+    private const int MaxDescriptionLength = 500;
+
+    public string Text { get; }
+
+    public static Description Empty = new Description("");
+
+    private Description(string text)
+    {
+        Text = text;
+    }
+
+    public static Result<Description> Create(string? description) =>
+        description switch
+        {
+            null => Empty,
+            not null when description.Length > MaxDescriptionLength => Result.Failure<Description>(
+                DescriptionErrors.DescriptionExceedsMaxLength(MaxDescriptionLength)
+            ),
+            _ => new Description(description),
+        };
+}
+
+public static class DescriptionErrors
+{
+    public static string DescriptionExceedsMaxLength(int maxLength) =>
+        $"Description can't be more than {maxLength} characters";
+}

--- a/src/PetFamily.Domain/SocialMedia/SocialMedia.cs
+++ b/src/PetFamily.Domain/SocialMedia/SocialMedia.cs
@@ -1,0 +1,18 @@
+using CSharpFunctionalExtensions;
+using PetFamily.Domain.SocialMedia.ValueObjects;
+
+namespace PetFamily.Domain.SocialMedia;
+
+public class SocialMedia : Entity
+{
+    public new SocialMediaId Id { get; init; }
+    public SocialMediaName Name { get; init; }
+    public SocialMediaUrl Url { get; init; }
+
+    public SocialMedia(SocialMediaName name, SocialMediaUrl url)
+    {
+        Id = new SocialMediaId();
+        Name = name;
+        Url = url;
+    }
+}

--- a/src/PetFamily.Domain/SocialMedia/ValueObjects/SocialMediaId.cs
+++ b/src/PetFamily.Domain/SocialMedia/ValueObjects/SocialMediaId.cs
@@ -1,0 +1,6 @@
+namespace PetFamily.Domain.SocialMedia.ValueObjects;
+
+public record SocialMediaId
+{
+    public Guid Id { get; } = Guid.NewGuid();
+}

--- a/src/PetFamily.Domain/SocialMedia/ValueObjects/SocialMediaName.cs
+++ b/src/PetFamily.Domain/SocialMedia/ValueObjects/SocialMediaName.cs
@@ -1,0 +1,31 @@
+using CSharpFunctionalExtensions;
+
+namespace PetFamily.Domain.SocialMedia.ValueObjects;
+
+public record SocialMediaName
+{
+    private const int SocialMediaNameMaxLength = 50;
+
+    public string Name { get; }
+
+    private SocialMediaName(string name) => Name = name;
+
+    public static Result<SocialMediaName> Create(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return Result.Failure<SocialMediaName>(SocialMediaNameErrors.NameIsEmpty());
+        if (name.Length > SocialMediaNameMaxLength)
+            return Result.Failure<SocialMediaName>(
+                SocialMediaNameErrors.NameExceedsLength(SocialMediaNameMaxLength)
+            );
+        return new SocialMediaName(name);
+    }
+}
+
+public static class SocialMediaNameErrors
+{
+    public static string NameIsEmpty() => "Social media name is empty";
+
+    public static string NameExceedsLength(int length) =>
+        $"Social media name exceeds length of {length} characters";
+}

--- a/src/PetFamily.Domain/SocialMedia/ValueObjects/SocialMediaUrl.cs
+++ b/src/PetFamily.Domain/SocialMedia/ValueObjects/SocialMediaUrl.cs
@@ -1,0 +1,27 @@
+using CSharpFunctionalExtensions;
+using PetFamily.Domain.Utils;
+
+namespace PetFamily.Domain.SocialMedia.ValueObjects;
+
+public record SocialMediaUrl
+{
+    public string Url { get; }
+
+    private SocialMediaUrl(string url) => Url = url;
+
+    public static Result<SocialMediaUrl> Create(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            return Result.Failure<SocialMediaUrl>(SocialMediaUrlErrors.UrlEmpty());
+        if (!UrlValidationHelper.IsUrlValid(url))
+            return Result.Failure<SocialMediaUrl>(SocialMediaUrlErrors.UrlIsInvalid());
+        return new SocialMediaUrl(url);
+    }
+}
+
+public static class SocialMediaUrlErrors
+{
+    public static string UrlEmpty() => "Social media Url was empty";
+
+    public static string UrlIsInvalid() => "Social media Url is invalid";
+}

--- a/src/PetFamily.Domain/Species/Breed.cs
+++ b/src/PetFamily.Domain/Species/Breed.cs
@@ -1,0 +1,18 @@
+using CSharpFunctionalExtensions;
+using PetFamily.Domain.Species.ValueObjects;
+
+namespace PetFamily.Domain.Species;
+
+public class Breed : Entity
+{
+    public new BreedId Id { get; init; }
+    public BreedName Name { get; private set; }
+
+    public Breed(BreedName name)
+    {
+        Id = new BreedId();
+        Name = name;
+    }
+
+    public void ChangeBreedName(BreedName name) => Name = name;
+}

--- a/src/PetFamily.Domain/Species/Specie.cs
+++ b/src/PetFamily.Domain/Species/Specie.cs
@@ -1,0 +1,31 @@
+using CSharpFunctionalExtensions;
+using PetFamily.Domain.Species.ValueObjects;
+
+namespace PetFamily.Domain.Species;
+
+public class Specie : Entity
+{
+    private readonly List<Breed> _breeds = [];
+
+    public new SpecieId Id { get; init; }
+
+    public SpecieType Type { get; private set; }
+
+    public IReadOnlyCollection<Breed> Breeds => _breeds;
+
+    public Specie(SpecieType type)
+    {
+        Id = new SpecieId();
+        Type = type;
+    }
+
+    public void ChangeSpecieType(SpecieType type) => Type = type;
+
+    public Result AddBreed(Breed breed)
+    {
+        if (_breeds.Any(b => b.Id == breed.Id || b.Name == breed.Name))
+            return Result.Failure("Such breed already exists in this specie");
+        _breeds.Add(breed);
+        return Result.Success();
+    }
+}

--- a/src/PetFamily.Domain/Species/ValueObjects/BreedId.cs
+++ b/src/PetFamily.Domain/Species/ValueObjects/BreedId.cs
@@ -1,0 +1,6 @@
+namespace PetFamily.Domain.Species.ValueObjects;
+
+public record BreedId
+{
+    public Guid Id { get; } = Guid.NewGuid();
+}

--- a/src/PetFamily.Domain/Species/ValueObjects/BreedName.cs
+++ b/src/PetFamily.Domain/Species/ValueObjects/BreedName.cs
@@ -1,0 +1,34 @@
+using CSharpFunctionalExtensions;
+
+namespace PetFamily.Domain.Species.ValueObjects;
+
+public record BreedName
+{
+    private const int MaxBreedValueLength = 100;
+    public string BreedValue { get; }
+
+    private BreedName(string breed) => BreedValue = breed;
+
+    public static Result<BreedName> Create(string? breed) =>
+        breed switch
+        {
+            null => Result.Failure<BreedName>(BreedNameErrors.BreedNameWasNull()),
+            not null when string.IsNullOrWhiteSpace(breed) => Result.Failure<BreedName>(
+                BreedNameErrors.BreedNameWasEmpty()
+            ),
+            not null when breed.Length > MaxBreedValueLength => Result.Failure<BreedName>(
+                BreedNameErrors.BreedNameValueExceedsMaxLength(MaxBreedValueLength)
+            ),
+            _ => new BreedName(breed),
+        };
+}
+
+public static class BreedNameErrors
+{
+    public static string BreedNameWasNull() => "Breed was null";
+
+    public static string BreedNameWasEmpty() => "Breed was empty";
+
+    public static string BreedNameValueExceedsMaxLength(int maxLength) =>
+        $"Breed value is more than {maxLength} characters";
+}

--- a/src/PetFamily.Domain/Species/ValueObjects/PersonName.cs
+++ b/src/PetFamily.Domain/Species/ValueObjects/PersonName.cs
@@ -1,0 +1,60 @@
+using CSharpFunctionalExtensions;
+
+namespace PetFamily.Domain.Species.ValueObjects;
+
+public record PersonName
+{
+    private const int MaxNamePartsLength = 50;
+
+    public string Name { get; }
+
+    public string Surname { get; }
+
+    public string Patronymic { get; }
+
+    private PersonName(string name, string surname, string patronymic = "")
+    {
+        Name = name;
+        Surname = surname;
+        Patronymic = patronymic;
+    }
+
+    public static Result<PersonName> Create(string? name, string? surname, string? patronymic)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return Result.Failure<PersonName>(PersonNameErrors.NameWasEmpty());
+        if (name.Length > MaxNamePartsLength)
+            return Result.Failure<PersonName>(
+                PersonNameErrors.NameExceedsLength(MaxNamePartsLength)
+            );
+        if (string.IsNullOrWhiteSpace(surname))
+            return Result.Failure<PersonName>(PersonNameErrors.SurnameWasEmpty());
+        if (surname.Length > MaxNamePartsLength)
+            return Result.Failure<PersonName>(
+                PersonNameErrors.SurnameExceedsLength(MaxNamePartsLength)
+            );
+        if (!string.IsNullOrWhiteSpace(patronymic) && patronymic.Length > MaxNamePartsLength)
+            return Result.Failure<PersonName>(
+                PersonNameErrors.PatronymicExceedsLength(MaxNamePartsLength)
+            );
+        return string.IsNullOrWhiteSpace(patronymic)
+            ? new PersonName(name, surname)
+            : new PersonName(name, surname, patronymic);
+    }
+}
+
+public static class PersonNameErrors
+{
+    public static string NameExceedsLength(int length) =>
+        $"Name cannot be more than {length} characters";
+
+    public static string SurnameExceedsLength(int length) =>
+        $"Name cannot be more than {length} characters";
+
+    public static string PatronymicExceedsLength(int length) =>
+        $"Name cannot be more than {length} characters";
+
+    public static string NameWasEmpty() => "Name was empty";
+
+    public static string SurnameWasEmpty() => "Surname was empty";
+}

--- a/src/PetFamily.Domain/Species/ValueObjects/SpecieId.cs
+++ b/src/PetFamily.Domain/Species/ValueObjects/SpecieId.cs
@@ -1,0 +1,6 @@
+namespace PetFamily.Domain.Species.ValueObjects;
+
+public record SpecieId
+{
+    public Guid Id { get; } = Guid.NewGuid();
+}

--- a/src/PetFamily.Domain/Species/ValueObjects/SpecieType.cs
+++ b/src/PetFamily.Domain/Species/ValueObjects/SpecieType.cs
@@ -1,0 +1,35 @@
+using CSharpFunctionalExtensions;
+
+namespace PetFamily.Domain.Species.ValueObjects;
+
+public record SpecieType
+{
+    private const int MaxSpecieTypeLength = 80;
+
+    public string Type { get; }
+
+    private SpecieType(string type) => Type = type;
+
+    public static Result<SpecieType> Create(string? type) =>
+        type switch
+        {
+            null => Result.Failure<SpecieType>(SpecieTypeErrors.SpecieTypeNullError()),
+            not null when string.IsNullOrWhiteSpace(type) => Result.Failure<SpecieType>(
+                SpecieTypeErrors.SpecieTypeEmptyError()
+            ),
+            not null when type.Length > MaxSpecieTypeLength => Result.Failure<SpecieType>(
+                SpecieTypeErrors.SpecieTypeExceedsLength(MaxSpecieTypeLength)
+            ),
+            _ => new SpecieType(type),
+        };
+}
+
+public static class SpecieTypeErrors
+{
+    public static string SpecieTypeNullError() => "Specie type was null";
+
+    public static string SpecieTypeEmptyError() => "Specie type was empty";
+
+    public static string SpecieTypeExceedsLength(int length) =>
+        $"Specie type cannot be more than {length} symbols";
+}

--- a/src/PetFamily.Domain/Utils/EmailValidationHelper.cs
+++ b/src/PetFamily.Domain/Utils/EmailValidationHelper.cs
@@ -1,0 +1,13 @@
+using System.Text.RegularExpressions;
+
+namespace PetFamily.Domain.Utils;
+
+public static class EmailValidationHelper
+{
+    private static readonly Regex EmailValidationRegex = new Regex(
+        @"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$",
+        RegexOptions.Compiled
+    );
+
+    public static bool IsEmailValid(string email) => EmailValidationRegex.IsMatch(email);
+}

--- a/src/PetFamily.Domain/Utils/PhoneValidationHelper.cs
+++ b/src/PetFamily.Domain/Utils/PhoneValidationHelper.cs
@@ -1,0 +1,13 @@
+using System.Text.RegularExpressions;
+
+namespace PetFamily.Domain.Utils;
+
+public static class PhoneValidationHelper
+{
+    private static readonly Regex PhoneValidationRegex = new Regex(
+        @"^(\+?\d{1,3}[- ]?)?\d{10}$",
+        RegexOptions.Compiled
+    );
+
+    public static bool IsPhoneValid(string phone) => PhoneValidationRegex.IsMatch(phone);
+}

--- a/src/PetFamily.Domain/Utils/UrlValidationHelper.cs
+++ b/src/PetFamily.Domain/Utils/UrlValidationHelper.cs
@@ -1,0 +1,10 @@
+namespace PetFamily.Domain.Utils;
+
+public static class UrlValidationHelper
+{
+    public static bool IsUrlValid(string url)
+    {
+        return Uri.TryCreate(url, UriKind.Absolute, out var uriResult)
+            && (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps);
+    }
+}

--- a/src/PetFamily.Domain/Volunteer/ValueObjects/ExperienceInYears.cs
+++ b/src/PetFamily.Domain/Volunteer/ValueObjects/ExperienceInYears.cs
@@ -1,0 +1,33 @@
+using CSharpFunctionalExtensions;
+
+namespace PetFamily.Domain.Volunteer.ValueObjects;
+
+public record ExperienceInYears
+{
+    public int Years { get; }
+
+    private ExperienceInYears(int years) => Years = years;
+
+    public static ExperienceInYears NoExperience = new ExperienceInYears(0);
+
+    public static Result<ExperienceInYears> Create(int years)
+    {
+        if (years < 0)
+            return Result.Failure<ExperienceInYears>(
+                ExperienceInYearsErrors.ExperienceCannotBeNegative()
+            );
+        if (years >= 100)
+            return Result.Failure<ExperienceInYears>(
+                ExperienceInYearsErrors.ExperienceCannotBeMoreThanHundred()
+            );
+        return new ExperienceInYears(100);
+    }
+}
+
+public static class ExperienceInYearsErrors
+{
+    public static string ExperienceCannotBeNegative() => "Experience cannot be negative value";
+
+    public static string ExperienceCannotBeMoreThanHundred() =>
+        "Experience cannot be more than 100 years";
+}

--- a/src/PetFamily.Domain/Volunteer/ValueObjects/VolunteerId.cs
+++ b/src/PetFamily.Domain/Volunteer/ValueObjects/VolunteerId.cs
@@ -1,0 +1,6 @@
+namespace PetFamily.Domain.Volunteer.ValueObjects;
+
+public record VolunteerId
+{
+    public Guid Id { get; } = Guid.NewGuid();
+}

--- a/src/PetFamily.Domain/Volunteer/Volunteer.cs
+++ b/src/PetFamily.Domain/Volunteer/Volunteer.cs
@@ -1,0 +1,83 @@
+using CSharpFunctionalExtensions;
+using PetFamily.Domain.Pet.ValueObjects;
+using PetFamily.Domain.Shared.ValueObjects;
+using PetFamily.Domain.Species.ValueObjects;
+using PetFamily.Domain.Volunteer.ValueObjects;
+
+namespace PetFamily.Domain.Volunteer;
+
+// волонтер
+public class Volunteer : Entity
+{
+    // животные волонтера
+    private readonly List<Pet.Pet> _pets = [];
+
+    // id волонтера
+    public new VolunteerId Id { get; init; }
+
+    // read-only коллекция животных волонтера
+    public IReadOnlyCollection<Pet.Pet> Pets => _pets;
+
+    // контактны
+    public Contacts Contacts { get; private set; }
+
+    // описание
+    public Description Description { get; private set; } = Description.Empty;
+
+    // ФИО
+    public PersonName Name { get; private set; }
+
+    // Опыт работы в годах
+    public ExperienceInYears Experience { get; private set; } = ExperienceInYears.NoExperience;
+
+    // реквизиты (опционально)
+    public AccountDetails AccountDetails { get; private set; } = AccountDetails.Unknown;
+
+    public Volunteer(
+        Contacts contacts,
+        PersonName name,
+        Description? description = null,
+        ExperienceInYears? experience = null
+    )
+    {
+        Id = new VolunteerId();
+        Contacts = contacts;
+        Name = name;
+        if (description != null)
+            Description = description;
+        if (experience != null)
+            Experience = experience;
+    }
+
+    public Result<int> GetCountOfPetsByStatus(int statusCode)
+    {
+        if (!Enum.IsDefined(typeof(PetHelpStatuses), statusCode))
+            return Result.Failure<int>(PetHelpStatusErrors.UnknownPetHelpStatus());
+        PetHelpStatuses status = (PetHelpStatuses)statusCode;
+        return _pets.Count(p => p.HelpStatus.StatusCode == status);
+    }
+
+    public Result CarryPet(Pet.Pet pet)
+    {
+        if (_pets.Any(p => p.Id == pet.Id))
+            return Result.Failure("Volunteer charges such pet already");
+        _pets.Add(pet);
+        return Result.Success();
+    }
+
+    public Result DropPet(PetId id)
+    {
+        if (!_pets.Any(p => p.Id == id))
+            return Result.Failure("Volunteer doesn't charge this pet");
+        _pets.RemoveAll(p => p.Id == id);
+        return Result.Success();
+    }
+
+    public Result<Pet.Pet> GetPet(Func<Pet.Pet, bool> predicate)
+    {
+        Pet.Pet? pet = _pets.FirstOrDefault(predicate);
+        if (pet == null)
+            return Result.Failure<Pet.Pet>("Volunteer doesn't charge this pet");
+        return pet;
+    }
+}


### PR DESCRIPTION
Привет. Делал VO на основе record типов. Подумал, что поскольку record'ы являются read-only почему бы их не использовать (мы не можем поменять значения свойств рекорда, а создание через with создаёт нам копию на основе существующего рекорда). Так же record'ы можно легко использовать для сравнения.

Мне кажется, что везде, где нужна кастомная валидация, можно вынести в отдельный тип.

Id сущности вынес в strongly-typed Ids. Они тоже являются рекордами.

Что можешь сказать о таком подходе к проектированию доменных сущностей?
